### PR TITLE
Call ensureDirSync to create parent directories on rotate

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -146,6 +146,8 @@ FileStreamRotator.getStream = function (options) {
     if (verbose) {
         console.log("Logging to", logfile);
     }
+    var logdir = path.dirname(logfile);
+    fs.ensureDirSync(logdir);
     var rotateStream = fs.createWriteStream(logfile, {flags: 'a'});
     if (curDate && frequencyMetaData && (frequencyMetaData.type == 'daily' || frequencyMetaData.type == 'h' || frequencyMetaData.type == 'm')) {
         if (verbose) {
@@ -165,8 +167,8 @@ FileStreamRotator.getStream = function (options) {
                 }
                 curDate = newDate;
                 logfile = newLogfile;
-                var logDir = path.dirname(newLogfile);
-                fs.ensureDirSync(logDir);
+                var newLogdir = path.dirname(newLogfile);
+                fs.ensureDirSync(newLogdir);
                 rotateStream.destroy();
                 rotateStream = fs.createWriteStream(newLogfile, {flags: 'a'});
             }

--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -9,7 +9,8 @@
 /**
  * Module dependencies.
  */
-var fs = require('fs');
+var fs = require('fs-extra');
+var path = require('path');
 var moment = require('moment');
 
 
@@ -164,6 +165,8 @@ FileStreamRotator.getStream = function (options) {
                 }
                 curDate = newDate;
                 logfile = newLogfile;
+                var logDir = path.dirname(newLogfile);
+                fs.ensureDirSync(logDir);
                 rotateStream.destroy();
                 rotateStream = fs.createWriteStream(newLogfile, {flags: 'a'});
             }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,31 @@
 {
-    "name": "file-stream-rotator",
-    "version": "0.0.6",
-    "description": "Automated stream rotation",
-    "main": "FileStreamRotator.js",
-    "scripts": {
-        "test": "node test.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/holidayextras/file-stream-rotator.git"
-    },
-    "keywords": [
-        "stream",
-        "express",
-        "restify",
-        "connect",
-        "rotate",
-        "file",
-        "minute",
-        "hourly",
-        "daily",
-        "logrotate"
-    ],
-    "author": "Roger Castells",
-    "license": "MIT",
-    "dependencies": {
-        "moment": "2.3.1"
-    }
+  "name": "file-stream-rotator",
+  "version": "0.0.6",
+  "description": "Automated stream rotation",
+  "main": "FileStreamRotator.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/holidayextras/file-stream-rotator.git"
+  },
+  "keywords": [
+    "stream",
+    "express",
+    "restify",
+    "connect",
+    "rotate",
+    "file",
+    "minute",
+    "hourly",
+    "daily",
+    "logrotate"
+  ],
+  "author": "Roger Castells",
+  "license": "MIT",
+  "dependencies": {
+    "fs-extra": "^0.21.0",
+    "moment": "2.3.1"
+  }
 }


### PR DESCRIPTION
Fixes holidayextras/file-stream-rotator#13

package.json looks very different, but really it's just the result of `npm install --save fs-extra`.
