### PR TITLE
Expose 'on' in rotateStream

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -150,7 +150,7 @@ FileStreamRotator.getStream = function (options) {
         if (verbose) {
             console.log("Rotating file", options.frequency);
         }
-        var stream = {end: rotateStream.end};
+        var stream = {end: rotateStream.end, on:rotateStream.on};
         stream.write = (function (str, encoding) {
             var newDate = this.getDate(frequencyMetaData,dateFormat);
             if (newDate != curDate) {


### PR DESCRIPTION
Expose 'on' in rotateStream to allow handling file stream events from outside (eg 'finish' event), to further process customized actions.