### PR TITLE
use existing file if current size is less than options.size

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -375,8 +375,14 @@ FileStreamRotator.getStream = function (options) {
         var t_log = logfile;
         var f = null;
         while(f = fs.existsSync(t_log)){
-            fileCount++;
-            t_log = logfile + "." + fileCount;
+            var stats = fs.statSync(t_log);
+            if (stats.size < fileSize) {
+                curSize = stats.size;
+                break;
+            } else {
+                fileCount++;
+                t_log = logfile + "." + fileCount;
+            }
         }
         logfile = t_log;
     }


### PR DESCRIPTION
When setting `options.size` the existing code would always create a new file. This PR re-uses the first existing file that is less than the value of `options.size`.