### PR TITLE
removing destroy in favor of end

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -432,7 +432,7 @@ FileStreamRotator.getStream = function (options) {
                 curDate = newDate;
                 oldFile = logfile;
                 logfile = newLogfile;
-                rotateStream.destroy();
+                rotateStream.end();
 
                 mkDirForFile(logfile);
 


### PR DESCRIPTION
When using this rotator in a very tight loop of 15 iterations, I am able to consistently make the component crash with `EBADF: bad file descriptor, write`. I narrowed this down to the destroy call on the stream. Reviewing https://nodejs.org/api/stream.html#stream_writable_destroy_error, I believe it's preferable to call end so the stream has a chance to write all the buffered data. 

Making this change l am able to run a tight loop of 15,000 iterations with no data loss. Request this be merged and published to npm.

Thank you.
