### PR TITLE
update addLogToAudit to avoid duplicate file in .audit.json

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -275,11 +275,18 @@ function removeFile(file){
 FileStreamRotator.addLogToAudit = function(logfile, audit){
     if(audit && audit.files){
         var time = Date.now();
-        audit.files.push({
-            date: time,
-            name: logfile,
-            hash: crypto.createHash('md5').update(logfile + "LOG_FILE" + time).digest("hex")
-        });
+        var index = audit.files.findIndex(file => (file.name === logfile))
+
+        if (index !== -1) {
+            audit.files[index].date = time;
+            audit.files[index].hash = crypto.createHash('md5').update(logfile + "LOG_FILE" + time).digest("hex");
+        } else {
+            audit.files.push({
+                date: time,
+                name: logfile,
+                hash: crypto.createHash('md5').update(logfile + "LOG_FILE" + time).digest("hex")
+            });
+        }
 
         if(audit.keep.days){
             var oldestDate = moment().subtract(audit.keep.amount,"days").valueOf();

--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -275,7 +275,9 @@ function removeFile(file){
 FileStreamRotator.addLogToAudit = function(logfile, audit){
     if(audit && audit.files){
         var time = Date.now();
-        var index = audit.files.findIndex(file => (file.name === logfile))
+        var index = audit.files.findIndex(function(file) {
+            return (file.name === logfile);
+        });
 
         if (index !== -1) {
             audit.files[index].date = time;


### PR DESCRIPTION
When application restart or call getStream function again, whatever the file name  changed or not it will be push into .audit.json file as new file, it will cause the unexpected error happened when max_logs is set.

So, before the file push into .audit.json , i check if same file in the .audit.json, if exist change the file date and hash, otherwise push into .audit.json.

Thank you.