### PR TITLE
allow passing of custom options to createWriteStream

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -47,6 +47,9 @@ var EventEmitter = require('events');
  *   - `end_stream`     End stream (true) instead of the default behaviour of destroy (false). Set value to true if when writing to the
  *                      stream in a loop, if the application terminates or log rotates, data pending to be flushed might be lost.                    
  *
+ *   - `file_options`   An object passed to the stream. This can be used to specify flags, encoding, and mode.
+ *                      See https://nodejs.org/api/all.thml#fs_fs_createwritestream_path_options. Default `{ flags: 'a' }`.
+ *
  * To use with Express / Connect, use as below.
  *
  * var rotatingLogStream = require('FileStreamRotator').getStream({filename:"/tmp/test.log", frequency:"daily", verbose: false})
@@ -330,6 +333,7 @@ FileStreamRotator.addLogToAudit = function(logfile, audit){
  * @param options.size
  * @param options.max_logs
  * @param options.audit_file
+ * @param options.file_options
  * @returns {Object} stream
  */
 FileStreamRotator.getStream = function (options) {
@@ -416,7 +420,8 @@ FileStreamRotator.getStream = function (options) {
 
     mkDirForFile(logfile);
 
-    var rotateStream = fs.createWriteStream(logfile, {flags: 'a'});
+    var file_options = options.file_options || {flags: 'a'};
+    var rotateStream = fs.createWriteStream(logfile, file_options);
     if (curDate && frequencyMetaData && (staticFrequency.indexOf(frequencyMetaData.type) > -1)) {
         if (verbose) {
             console.log(new Date(),"[FileStreamRotator] Rotating file: ", frequencyMetaData.type);
@@ -465,7 +470,7 @@ FileStreamRotator.getStream = function (options) {
 
                 mkDirForFile(logfile);
 
-                rotateStream = fs.createWriteStream(newLogfile, {flags: 'a'});
+                rotateStream = fs.createWriteStream(newLogfile, file_options);
                 stream.emit('new',newLogfile);
                 stream.emit('rotate',oldFile, newLogfile);
                 BubbleEvents(rotateStream,stream);


### PR DESCRIPTION
This additional option could be used to specify custom permissions for the log files (e.g., group writable). Thank you for considering.