### PR TITLE
Fix symlink already exists exception

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -300,7 +300,12 @@ function createCurrentSymLink(logfile, name) {
         }
     } catch (err) {
         if(err && err.code == "ENOENT") {
-            fs.symlinkSync(logfileName, current)
+            try {
+                fs.symlinkSync(logfileName, current)
+            }
+            catch (e) {
+                console.error(new Date(), "[FileStreamRotator] Could not create symlink file: ", current, ' -> ', logfileName);
+            }
         }
     }
 }


### PR DESCRIPTION
Symlink already exists exception may be thrown when there has multi process concurrency execution eg. run in PM2 cluster mode

process `uncaughtException` Exception：

```txt
Error: EEXIST: file already exists, symlink 'current_YYYYMMDD.log' -> '/data/tcblog/'current.log'
```