### PR TITLE
fix: newDate do not get in the same way as curDate

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -562,7 +562,10 @@ FileStreamRotator.getStream = function (options) {
 
 
         stream.write = (function (str, encoding) {
-            var newDate = this.getDate(frequencyMetaData, dateFormat, options.utc);
+            var newDate = "";
+            if (frequencyMetaData) {
+                newDate = (options.frequency ? this.getDate(frequencyMetaData,dateFormat, options.utc) : "");
+            }
             if (newDate != curDate || (fileSize && curSize > fileSize)) {
                 var newLogfile = filename + (curDate ? "." + newDate : "");
                 if(filename.match(/%DATE%/) && curDate){


### PR DESCRIPTION
when I set frequency empty, it is right not to add date in the end of the filename.
But it goes wrong when the file reach its maxsize and rotate, it add date in the end.
It is because the newDate do not calculate in the same way as curDate.