### PR TITLE
fix Throw exist error on mkdirSync

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -651,7 +651,13 @@ var mkDirForFile = function(pathWithFile){
             //     console.log("STATS ERROR",e)
             // }
             if (!fs.existsSync(fullPath)) {
-                fs.mkdirSync(fullPath);
+                try{
+                    fs.mkdirSync(fullPath);
+                }catch(e){
+                    if(e.code !== 'EEXIST'){
+                        throw e;
+                    }
+                }
             }
             return fullPath;
         },


### PR DESCRIPTION
When multiple processes are started at the same time, an existed error may occur when creating a folder.
Fixed mkdirSync to not throw an error if it was an existed error.