### PR TITLE
Emitting "new" event when the logfile is re-created after deletion so that the watcher is readded

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -570,6 +570,7 @@ FileStreamRotator.getStream = function (options) {
                     rotateStream.end();
                 }
                 rotateStream = fs.createWriteStream(file, file_options);
+                stream.emit('new',file);
                 BubbleEvents(rotateStream,stream);
             }
         });


### PR DESCRIPTION
Issue: when watch_log is set to true, the log file is only recreated once. E.g log file is created > log file deleted > watcher detects deletion and recreate the file however the log file is not recreated on any subsequent deletion.

