### PR TITLE
fix don't emitting first "logRemoved" event

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -634,7 +634,6 @@ FileStreamRotator.getStream = function (options) {
         process.nextTick(function(){
             stream.emit('new',logfile);
         })
-        stream.emit('new',logfile)
         return stream;
     } else {
         if (self.verbose) {


### PR DESCRIPTION
fix don't emitting event about deleting oldest file which should be emitted each time when server restarting (https://github.com/winstonjs/winston-daily-rotate-file/issues/296 issue)
reason in double emitting "new" event when app started, and first emit happens before stream returning and no one can hear "logRemoved" event