### PR TITLE
Added TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { WriteStream, WriteFileOptions } from "fs";
+import type { WriteStream, WriteFileOptions } from "fs";
 
 export type StreamOptions = {
     filename: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+import { WriteStream, WriteFileOptions } from "fs";
+
+export type StreamOptions = {
+    filename: string;
+    frequency?: string;
+    verbose?: boolean;
+    date_format?: string;
+    size?: string;
+    audit_file?: string;
+    end_stream?: boolean;
+    file_options?: WriteFileOptions;
+    utc?: boolean;
+    extension?: string;
+    watch_log?: boolean;
+    create_symlink?: boolean;
+    symlink_name?: string;
+    audit_hash_type?: "md5" | "sha256";
+};
+
+export function getStream(options: StreamOptions): WriteStream;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export type StreamOptions = {
     verbose?: boolean;
     date_format?: string;
     size?: string;
+    max_logs?: number | `${number}d`;
     audit_file?: string;
     end_stream?: boolean;
     file_options?: WriteFileOptions;


### PR DESCRIPTION
I added TypeScript declarations in `index.d.ts`, which provide TypeScript support and offer better IntelliSense completions for JavaScript. Node.js automatically searches for a file called `index.d.ts` in the project root, so there's no need to modify `package.json`. Thanks for creating this package! 