### PR TITLE
Fix handling special characters in filename path

### DIFF
--- a/FileStreamRotator.js
+++ b/FileStreamRotator.js
@@ -123,6 +123,16 @@ var _checkDailyAndTest = function (freqType) {
     return false;
 }
 
+/**
+ * Sanitizes regular expression string
+ * @param {string} regExpString
+ * @returns {string}
+ * @private
+ */
+ var _escapeRegexp = function (regExpString) {
+    return regExpString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
 
 /**
  * Returns frequency metadata
@@ -493,8 +503,8 @@ FileStreamRotator.getStream = function (options) {
         var f = null;
         if(auditLog && auditLog.files && auditLog.files instanceof Array && auditLog.files.length > 0){
             var lastEntry = auditLog.files[auditLog.files.length - 1].name;
-            if(lastEntry.match(t_log)){
-                var lastCount = lastEntry.match(t_log + "\\.(\\d+)");
+            if(lastEntry.match(_escapeRegexp(t_log))){
+                var lastCount = lastEntry.match(_escapeRegexp(t_log) + "\\.(\\d+)");
                 // Thanks for the PR contribution from @andrefarzat - https://github.com/andrefarzat
                 if(lastCount){                    
                     t_log = lastEntry;

--- a/test.js
+++ b/test.js
@@ -156,6 +156,7 @@ var tests = {
             var options3 = { filename: logdir + 'program3-%DATE%.log', frequency: '1m', verbose: true, date_format: 'YYYY-MM-DD'};
             var options4 = { filename: logdir + 'program4-%DATE%.log', verbose: true, date_format: 'YYYY-MM-DD'};
             var options5 = { filename: logdir + 'program5-%DATE%.log', verbose: true};
+            var options6 = { filename: logdir + '/special-characters-test-logs))/program.log', verbose: true, size: '1m', max_logs: 20};
 
             var stream1 = fsr.getStream(options1);
             stream1.write('formatted date');
@@ -166,7 +167,14 @@ var tests = {
             var stream4 = fsr.getStream(options4);
             stream4.write('date mid filename without rotation');
             var stream5 = fsr.getStream(options5);
-            stream5.write('dafault date mid filename without rotation');
+            stream5.write('default date mid filename without rotation');
+
+
+            // Get stream twice to test how it behaves when the audit file already exists
+            var stream6a = fsr.getStream(options6);
+            stream6a.write('special characters in a filename path A');
+            var stream6b = fsr.getStream(options6);
+            stream6b.write('special characters in a filename path B');
 
 
             var options = { filename: logdir + 'program-%DATE%.log', frequency: '1m', verbose: true, date_format: 'YYYY-MM-DD:HH:mm' };


### PR DESCRIPTION
Hey, I noticed a bug related to handling paths with special characters (for example `special-characters-test-logs))/program.log`):
<img width="1116" alt="regex-error" src="https://user-images.githubusercontent.com/39515152/182355368-45714c6d-ec9c-4875-8c98-05f12c264272.png">

It matters a lot when the code is executed on clients' machines (for example in [Electron](https://www.electronjs.org/) applications) because the paths can't be trusted and need to be sanitized before creating a regex.

I included a test that shows what used to fail. I don't know why the `testGetStream` function in `test.js` starts with `return` statement (which effectively disables that part of tests), but once you remove the return statement, the tests work fine.