### PR TITLE
Emit 'logRemoved' event for files which are removed from disk

### DIFF
--- a/src/AuditManager.ts
+++ b/src/AuditManager.ts
@@ -101,6 +101,9 @@ export default class AuditManager {
                     fs.unlinkSync(logEntry.name);
                     this.emitter.emit("logRemoved", logEntry.name)
                 }
+                else {
+                    this.emitter.emit("logRemoved", logEntry.name)
+                }
             }catch(e){
                 Logger.verbose("Could not remove old log file: ", logEntry.name);
             }


### PR DESCRIPTION
Currently this library is not emitting `logRemoved` event for files inside Audit JSON which are actually deleted from disk. 

This causes issues for example in `winston-daily-rotate-file` which is providing gzip functionality and it compresses the original log files and then removes them from disk.

Now, because this remove event is not emitted winston-daily-rotate-file cannot delete those `.gz` files.

It is safe to emit this event because original log file is deleted. Whether deletion is done by file-stream-rotator or someone else.